### PR TITLE
docs: fix readme link

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,10 @@
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"editor.formatOnSave": true,
 	"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"workbench.colorCustomizations": {
+		"activityBar.background": "#1A3407",
+		"titleBar.activeBackground": "#24490A",
+		"titleBar.activeForeground": "#F5FDEE"
+	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,10 +5,5 @@
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"editor.formatOnSave": true,
 	"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-	"typescript.tsdk": "node_modules/typescript/lib",
-	"workbench.colorCustomizations": {
-		"activityBar.background": "#1A3407",
-		"titleBar.activeBackground": "#24490A",
-		"titleBar.activeForeground": "#F5FDEE"
-	}
+	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Linting TypeScript in 2023 Code</h1>
 
-<p align="center">Demo app for linting React and TypeScript with typescript-eslint, formed from my <a href="github.com/JoshuaKGoldberg/template-typescript-node-package">template-typescript-node-package</a>. ✨</p>
+<p align="center">Demo app for linting React and TypeScript with typescript-eslint, formed from my <a href="https://github.com/JoshuaKGoldberg/template-typescript-node-package">template-typescript-node-package</a>. ✨</p>
 
 <p align="center">
 	<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to linting-typescript-in-2023! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/linting-typescript-in-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/linting-typescript-in-2023/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Typo in the repo's README as to the link of the demo repo. Added the "https://" to the beginning of the link :)

PS: I might open it in a new tab as well! 

Thanks for the article on setting up prettier and eslint!