### PR TITLE
Update .eslintrc.cjs comment

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,7 +5,7 @@ I added two plugins that auto-sort keys in JS/TS files:
 	* eslint-plugin-simple-import-sort
 	* eslint-plugin-typescript-sort-keys
 
-I added eslint-plugin-jsdoc to auto-sort keys in .json files
+I added eslint-plugin-jsonc to auto-sort keys in .json files
 
 I use the react/jsx-runtime config instead of react/recommended.
 See https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc.


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to linting-typescript-in-2023! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/linting-typescript-in-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/linting-typescript-in-2023/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
A small typo in the comments at `.eslintrc.cjs` file.
It says that `eslint-plugin-jsdoc` is being used to sort the .json file, I believe the author meant to `eslint-plugin-jsonc`.
<!-- Description of what is changed and how the code change does that. -->
